### PR TITLE
Fix import path for scraper in Flask app

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,10 @@
 from flask import Flask, render_template, request, jsonify, Response, send_file
-from letterboxd_scraper import LetterboxdScraper
+# Import the scraper from the `api` package. When running the application
+# locally with `python app.py`, the scraper lives inside the `api` package so we
+# need to use the package import. The previous absolute import failed with a
+# `ModuleNotFoundError` because `letterboxd_scraper.py` does not exist at the
+# project root.
+from api.letterboxd_scraper import LetterboxdScraper
 from flask_wtf import CSRFProtect
 import os
 import requests


### PR DESCRIPTION
## Summary
- fix missing module error when running `app.py`

## Testing
- `python3 -m py_compile app.py api/index.py api/letterboxd_scraper.py letterboxd.py`
- `python3 app.py` *(fails to serve because environment lacks Vercel, but server starts successfully)*

------
https://chatgpt.com/codex/tasks/task_e_6875229234b483238aa7cc077b8ab016