### PR TITLE
Fix config section French text

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Ce projet est sous licence MIT. Voir le fichier `LICENSE` pour plus de détails.
 Créez un fichier `config.ini` :
 ```ini
 [letterboxd]
-remplacer l'url par l'url de la liste ou watchlist voulu
+Remplacez l’URL par l’URL de la liste ou watchlist voulue
 ```
 
 ## 📸 Exemple de sortie


### PR DESCRIPTION
## Summary
- fix French instructions in Configuration section of README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68752474b9bc83238733d1377189a0c1