### PR TITLE
Add unit tests for scraper URL validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask-wtf==1.0.0
 requests==2.26.0
 beautifulsoup4==4.9.3
 html5lib==1.1
+pytest==8.1.1

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,0 +1,32 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+from api.letterboxd_scraper import LetterboxdScraper
+
+
+def test_valid_watchlist_url():
+    scraper = LetterboxdScraper()
+    url = "https://letterboxd.com/johndoe/watchlist/"
+    assert scraper._is_valid_letterboxd_list_url(url) is True
+    assert scraper.username == "johndoe"
+    assert scraper.list_type == "watchlist"
+
+def test_valid_films_url():
+    scraper = LetterboxdScraper()
+    url = "https://letterboxd.com/janedoe/films/"
+    assert scraper._is_valid_letterboxd_list_url(url) is True
+    assert scraper.username == "janedoe"
+    assert scraper.list_type == "films"
+
+def test_custom_list_url():
+    scraper = LetterboxdScraper()
+    url = "https://letterboxd.com/list/my-custom-list/"
+    assert scraper._is_valid_letterboxd_list_url(url) is True
+    assert scraper.list_type == "list"
+    assert scraper.list_slug == "my-custom-list"
+
+def test_invalid_url():
+    scraper = LetterboxdScraper()
+    url = "https://example.com/not-a-list/"
+    assert scraper._is_valid_letterboxd_list_url(url) is False
+


### PR DESCRIPTION
## Summary
- add pytest to dependencies
- create tests directory with unit tests
- verify `_is_valid_letterboxd_list_url` handles watchlist, films, custom lists and invalid URLs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6875249517348323aa8dd05600a43344